### PR TITLE
fix vars in zipkin tasks

### DIFF
--- a/ansible/roles/zipkin/tasks/collector.yml
+++ b/ansible/roles/zipkin/tasks/collector.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download zipkin collector service
-  get_url: url='{{zipkin_repo}}'/io/zipkin/zipkin-collector-service/'{{zipkin_version}}'/zipkin-collector-service-'{{zipkin_version}}'-all.jar
+  get_url: url={{zipkin_repo}}/io/zipkin/zipkin-collector-service/{{zipkin_version}}/zipkin-collector-service-{{zipkin_version}}-all.jar
            dest=/usr/share/zipkin-collector.jar
   sudo: yes
 

--- a/ansible/roles/zipkin/tasks/main.yml
+++ b/ansible/roles/zipkin/tasks/main.yml
@@ -2,7 +2,7 @@
 - include: cassandra.yml
   
 - name: Download zipkin schema
-  get_url: url=https://raw.githubusercontent.com/openzipkin/zipkin/'{{zipkin_version}}'/zipkin-cassandra-core/src/main/resources/cassandra-schema-cql3.txt
+  get_url: url=https://raw.githubusercontent.com/openzipkin/zipkin/{{zipkin_version}}/zipkin-cassandra-core/src/main/resources/cassandra-schema-cql3.txt
            dest=/tmp
   sudo: yes
 

--- a/ansible/roles/zipkin/tasks/query.yml
+++ b/ansible/roles/zipkin/tasks/query.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download zipkin query service
   sudo: yes
-  get_url: url='{{zipkin_repo}}'/io/zipkin/zipkin-query-service/'{{zipkin_version}}'/zipkin-query-service-'{{zipkin_version}}'-all.jar
+  get_url: url={{zipkin_repo}}/io/zipkin/zipkin-query-service/{{zipkin_version}}/zipkin-query-service-{{zipkin_version}}-all.jar
            dest=/usr/share/zipkin-query.jar
 
 - name: Copy startup script to /etc/init

--- a/ansible/roles/zipkin/tasks/web.yml
+++ b/ansible/roles/zipkin/tasks/web.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download zipkin web service
   sudo: yes
-  get_url: url='{{zipkin_repo}}'/io/zipkin/zipkin-web/'{{zipkin_version}}'/zipkin-web-'{{zipkin_version}}'-all.jar
+  get_url: url={{zipkin_repo}}/io/zipkin/zipkin-web/{{zipkin_version}}/zipkin-web-{{zipkin_version}}-all.jar
            dest=/usr/share/zipkin-web.jar
 
 - name: Copy startup script to /etc/init


### PR DESCRIPTION
there are single quote marks around the zipkin vars in the zipkin tasks.  this pr removes them and lets vagrant provision work.
